### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/amenable.gemspec
+++ b/amenable.gemspec
@@ -1,13 +1,15 @@
 require_relative "lib/amenable/version"
-package = Amenable
-
 
 Gem::Specification.new do |s|
-  s.name        = File.basename(__FILE__).split(".")[0]
-  s.version     = package.const_get 'VERSION'
+  s.name        = 'amenable'
+  s.version     = Amenable::VERSION
   s.authors     = ['Daniel Pepper']
-  s.summary     = package.to_s
-  s.description = 'Flexibility when you need it.'
+  s.summary     = 'Amenable'
+  s.description = <<~DESCRIPTION
+    A refinement that strips excess positional and keyword arguments
+    from method calls, so callers can pass extras without raising
+    ArgumentError.
+  DESCRIPTION
   s.homepage    = "https://github.com/dpep/amenable_rb"
   s.license     = 'MIT'
   s.files       = `git ls-files * ':!:spec'`.split("\n")


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and looks for assignments like `s.version = SomeConst::VERSION` or string literals. The dynamic forms we had defeated that:

```ruby
s.name    = File.basename(__FILE__).split(".")[0]   # dynamic
s.version = package.const_get 'VERSION'             # dynamic
```

When dependabot can't extract the version statically, it falls back to `0.0.1` and writes that into `Gemfile.lock`. CI then fails in frozen mode because the lockfile no longer matches the gemspec's actual version.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = 'amenable'
s.version = Amenable::VERSION
```

`lib/amenable/version.rb` remains the single source of truth.

While here, replaced the vague `'Flexibility when you need it.'` description with a heredoc that actually describes what the gem does.

## Test plan

- [x] `Bundler.load_gemspec("amenable.gemspec")` returns name `amenable`, version `0.1.0`
- [x] `bundle install` produces no `Gemfile.lock` diff
- [x] Full spec suite passes (44/44)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
